### PR TITLE
Modernize packaging: migrate to pyproject.toml, update CI

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -1,19 +1,14 @@
-# This workflows will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
 name: tests
 
 on:
   push:
     branches:
       - main
-      - npe2
     tags:
-      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v*"
   pull_request:
     branches:
       - main
-      - npe2
   workflow_dispatch:
 
 jobs:
@@ -23,68 +18,56 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
-      # these libraries enable testing on Qt on linux
       - uses: tlambert03/setup-qt-libs@v1
 
-      # strategy borrowed from vispy for installing opengl libs on windows
       - name: Install Windows OpenGL
         if: runner.os == 'Windows'
         run: |
           git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
 
-      # note: if you need dependencies from conda, considering using
-      # setup-miniconda: https://github.com/conda-incubator/setup-miniconda
-      # and
-      # tox-conda: https://github.com/tox-dev/tox-conda
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install setuptools tox tox-gh-actions
 
-      # this runs the platform-specific tests declared in tox.ini
       - name: Test with tox
-        uses: GabrielBB/xvfb-action@v1
+        uses: aganders3/headless-gui@v2
         with:
           run: python -m tox
         env:
           PLATFORM: ${{ matrix.platform }}
 
       - name: Coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5
 
   deploy:
-    # this will run when you have tagged a commit, starting with "v*"
-    # and requires that you have put your twine API key in your
-    # github secrets (see readme for details)
     needs: [test]
     runs-on: ubuntu-latest
     if: contains(github.ref, 'tags')
+    permissions:
+      id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -U setuptools setuptools_scm wheel twine build
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TWINE_API_KEY }}
-        run: |
-          git tag
-          python -m build .
-          twine upload dist/*
+          pip install -U setuptools wheel build
+      - name: Build
+        run: python -m build .
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,0 @@
-include LICENSE
-include README.md
-include pyproject.toml
-recursive-include src/napari_conference *.py
-recursive-include src/napari_conference *.yaml
-recursive-exclude * __pycache__
-recursive-exclude * *.py[co]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,17 @@
+[build-system]
+requires = ["setuptools>=61.0.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "napari-conference"
-version = "0.1.0"
+dynamic = ["version"]
 description = "A simple plugin that allows you to use napari + your webcam in video calls"
 readme = "README.md"
-requires-python = ">=3.8"
 license = { text = "BSD-3-Clause" }
 authors = [
     { name = "Kyle Harrington", email = "czi@kyleharrington.com" },
 ]
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Framework :: napari",
@@ -17,9 +21,10 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Image Processing",
 ]
 dependencies = [
@@ -28,15 +33,7 @@ dependencies = [
     "qtpy",
     "opencv-python",
     "pyvirtualcam",
-    "napari[all]>=0.4.19.post1",
-    "pyside6>=6.6.3.1",
 ]
-
-[project.urls]
-"Bug Tracker" = "https://github.com/kephale/napari-conference/issues"
-"Documentation" = "https://github.com/kephale/napari-conference#README.md"
-"Source Code" = "https://github.com/kephale/napari-conference"
-"User Support" = "https://github.com/kephale/napari-conference/issues"
 
 [project.optional-dependencies]
 testing = [
@@ -48,18 +45,27 @@ testing = [
     "pyqt5",
 ]
 
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[tool.hatch.build]
-packages = ["src/napari_conference"]
-
-[tool.hatch.metadata]
-allow-direct-references = true
+[project.urls]
+"Bug Tracker" = "https://github.com/kephale/napari-conference/issues"
+"Documentation" = "https://github.com/kephale/napari-conference#README.md"
+"Source Code" = "https://github.com/kephale/napari-conference"
+"User Support" = "https://github.com/kephale/napari-conference/issues"
 
 [project.entry-points."napari.manifest"]
-"napari-conference" = "napari_conference:napari.yaml"
+napari-conference = "napari_conference:napari.yaml"
+
+[tool.setuptools]
+package-dir = { "" = "src" }
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+"*" = ["*.yaml"]
+
+[tool.setuptools.dynamic]
+version = { attr = "napari_conference.__version__" }
 
 [tool.black]
 line-length = 79

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,14 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{38,39,310}-{linux,macos,windows}
+envlist = py{310,311,312,313}-{linux,macos,windows}
 isolated_build=true
 
 [gh-actions]
 python =
-    3.8: py38
-    3.9: py39
     3.10: py310
+    3.11: py311
+    3.12: py312
+    3.13: py313
 
 [gh-actions:env]
 PLATFORM =


### PR DESCRIPTION
## Summary
- Consolidate pyproject.toml with setuptools backend (was hatchling), dynamic version
- Remove heavy pinned deps (napari[all], pyside6) from install_requires
- Update Python version support to 3.10-3.13
- Update CI: actions/checkout@v4, setup-python@v5, headless-gui@v2, codecov@v5
- Switch PyPI deploy to trusted publisher (pypa/gh-action-pypi-publish)
- Update tox.ini for tox4 and Python 3.10-3.13
- Remove MANIFEST.in

🤖 Generated with [Claude Code](https://claude.com/claude-code)